### PR TITLE
Renamed KubeColor to kubecolor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "astro",
+        "astrojs",
+        "kubecolor"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # kubecolor
 
-KubeColor is a `kubectl` replacement used to add colors to your kubectl output.
+Kubecolor is a `kubectl` replacement used to add colors to your kubectl output.
 
-This repo contains the documentation and website (Github Pages) for [KubeColor Project](https://github.com/kubecolor/kubecolor)
+This repo contains the documentation and website (Github Pages) for the [kubecolor project](https://github.com/kubecolor/kubecolor)
 
 # Build
 
@@ -33,6 +33,6 @@ MIT
 
 ## Author
 
-This project is a heavily modified version of the original KubeColor now archived at [https://github.com/hidetatz/kubecolor](https://github.com/hidetatz/kubecolor)
+This project is a heavily modified version of the original kubecolor now archived at [https://github.com/hidetatz/kubecolor](https://github.com/hidetatz/kubecolor)
 
 [@kubecolor](https://github.com/kubecolor)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # kubecolor
 
-Kubecolor is a `kubectl` replacement used to add colors to your kubectl output.
+Kubecolor is a `kubectl` wrapper used to add colors to your kubectl output.
 
 This repo contains the documentation and website (Github Pages) for the [kubecolor project](https://github.com/kubecolor/kubecolor)
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
   	// base: '',
 	integrations: [
 		starlight({
-			title: 'KubeColor',
+			title: 'kubecolor',
 			logo: {
 				src: './src/assets/kubecolor_logo.svg',
 			},

--- a/src/content/docs/guides/examples/examples.mdx
+++ b/src/content/docs/guides/examples/examples.mdx
@@ -1,6 +1,6 @@
 ---
 title: Examples
-description: How to use KubeColor
+description: How to use kubecolor
 sidebar:
   order: 10
 ---

--- a/src/content/docs/guides/install.mdx
+++ b/src/content/docs/guides/install.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Guide
-description: How to install KubeColor
+description: How to install kubecolor
 sidebar:
   order: 1
 ---

--- a/src/content/docs/guides/setup.mdx
+++ b/src/content/docs/guides/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setup Guide
-description: How to configure your terminal to use KubeColor
+description: How to configure your terminal to use kubecolor
 sidebar:
   order: 2
 ---

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: kubecolor
-description: a kubectl replacement used to add colors to your kubectl output.
+description: a kubectl wrapper used to add colors to your kubectl output.
 template: splash
 hero:
-  tagline: a kubectl replacement used to add colors to your kubectl output.
+  tagline: a kubectl wrapper used to add colors to your kubectl output.
   image:
     file: ../../assets/kubecolor_logo.svg
   actions:

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: KubeColor
+title: kubecolor
 description: a kubectl replacement used to add colors to your kubectl output.
 template: splash
 hero:
@@ -29,6 +29,6 @@ hero:
 # Demo
 Tired of reading with monochrome in your termnal ? 
 
-**This is what KubeColor can do for you**:
+**This is what kubecolor can do for you**:
 
 ![ex](/assets/kubectl-combined.png)


### PR DESCRIPTION
# Description

<!--  Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changing the canonical form of the name of the project.

| Before | After |
| --- | --- |
| ![image](https://github.com/kubecolor/kubecolor.github.io/assets/2477952/7c65f368-aacc-4919-9653-b60b06266d45) | ![image](https://github.com/kubecolor/kubecolor.github.io/assets/2477952/cc1b01ba-4694-41d6-a093-fd5d2490a559)



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What you changed

- Renamed KubeColor to kubecolor in:
  - title
  - content of various pages
- Also rephrased kubecolor being a "kubectl wrapper", and not a "kubectl replacement", as kubecolor still depend on you having kubectl installed

## Why you think we should change it

Don't know how you feel about this, but I think "kubecolor" looks better than "KubeColor". Especially as it's primarily a CLI tool and so closely related to "kubectl" ([which is written in lowercase too](https://kubernetes.io/docs/reference/kubectl/quick-reference/), and not "KubeCtl" nor "KubeCTL")

I think we should change the canonical form of kubecolor to "kubecolor" (or "Kubecolor" when its the first word of the sentence).

## Related issue (if exists)
