### PR TITLE
`color.yaml` not `config.yaml`

### DIFF
--- a/src/content/docs/customizing/themes.mdx
+++ b/src/content/docs/customizing/themes.mdx
@@ -73,7 +73,7 @@ There's three way to switch to a different color theme:
 - Configuring the default theme in the configuration file at `~/.kube/color.yaml`:
 
   ```yaml
-  # ~/.kube/config.yaml
+  # ~/.kube/color.yaml
   preset: protanopia-dark
   ```
 


### PR DESCRIPTION
Everything else refers to `~/.kube/color.yaml` so I presume the comment referring to `~/.kube/config.yaml` was just a mistake.