### PR TITLE
docs: Add installation instructions for asdf and mise package managers

### DIFF
--- a/src/content/docs/setup/install.mdx
+++ b/src/content/docs/setup/install.mdx
@@ -104,6 +104,24 @@ Running it via Docker can be nice for just trying out kubecolor:
 docker run --rm -it -v $HOME/.kube:/home/nonroot/.kube:ro ghcr.io/kubecolor/kubecolor get pods
 ```
 
+== asdf
+
+For users using the [asdf](https://github.com/asdf-vm/asdf) package manager.
+
+```sh
+asdf plugin-add kubecolor https://github.com/dex4er/asdf-kubecolor.git
+asdf install kubecolor latest
+asdf global kubecolor latest
+```
+
+== mise
+
+For users using the [mise](https://github.com/jdx/mise) package manager.
+
+```sh
+mise use kubecolor
+```
+
 :::note
 If you're getting the error <code>permission denied</code>  (common in environments like WSL):
 

--- a/src/content/docs/setup/install.mdx
+++ b/src/content/docs/setup/install.mdx
@@ -84,6 +84,22 @@ For Android users using the [Termux](https://github.com/termux/termux-app) app.
 pkg install kubecolor
 ```
 
+## asdf
+
+For users using the [asdf](https://github.com/asdf-vm/asdf) package manager.
+
+```sh
+asdf install kubecolor latest
+```
+
+## mise
+
+For users using the [mise](https://github.com/jdx/mise) package manager.
+
+```sh
+mise use kubecolor
+```
+
 ## Download binary via GitHub release
 
 Go to [Release page](https://github.com/kubecolor/kubecolor/releases) then download the binary which fits your environment.
@@ -102,24 +118,6 @@ Running it via Docker can be nice for just trying out kubecolor:
 
 ```sh
 docker run --rm -it -v $HOME/.kube:/home/nonroot/.kube:ro ghcr.io/kubecolor/kubecolor get pods
-```
-
-== asdf
-
-For users using the [asdf](https://github.com/asdf-vm/asdf) package manager.
-
-```sh
-asdf plugin-add kubecolor https://github.com/dex4er/asdf-kubecolor.git
-asdf install kubecolor latest
-asdf global kubecolor latest
-```
-
-== mise
-
-For users using the [mise](https://github.com/jdx/mise) package manager.
-
-```sh
-mise use kubecolor
 ```
 
 :::note


### PR DESCRIPTION
Add Package Manager Installation Instructions for asdf and mise.

# Description

This PR adds installation instructions for users of the asdf and mise package managers. These additions will help users who prefer these package management systems to easily install and manage kubecolor. By including both asdf and mise, we cater to users of traditional and newer package management tools, improving the accessibility of kubecolor for a wider range of users.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What you changed

- Added instructions for installing kubecolor using asdf
- Added instructions for installing kubecolor using mise (formerly rtx)

## Why you think we should change it

This change improves the documentation by providing installation instructions for both asdf and mise package managers. It helps users easily install and manage kubecolor, catering to a wider audience with different preferences.

## Related issue (if exists)
