### PR TITLE
Remove 'New' badge

### DIFF
--- a/src/content/docs/customizing/themes.mdx
+++ b/src/content/docs/customizing/themes.mdx
@@ -2,10 +2,6 @@
 title: Color themes
 description: Changing the colors to your liking
 sidebar:
-  # Add a badge to the link
-  badge:
-    text: New
-    variant: tip
   order: 3
 ---
 

--- a/src/content/docs/setup/install.mdx
+++ b/src/content/docs/setup/install.mdx
@@ -45,7 +45,7 @@ brew install kubecolor
 
 :::
 
-## MacPorts <Badge text="New" variant="tip" />
+## MacPorts
 
 [![MacPorts version](https://repology.org/badge/version-for-repo/macports/kubecolor.svg)](https://repology.org/project/kubecolor/versions)
 
@@ -55,7 +55,7 @@ For MacOS users using the [MacPorts](https://www.macports.org/) package manager.
 sudo port install kubecolor
 ```
 
-## DEB <Badge text="New" variant="tip" />
+## DEB
 
 [![debian version from custom repo](https://img.shields.io/github/v/release/kubecolor/kubecolor?label=deb%20package&color=4cc61f)](https://github.com/kubecolor/kubecolor/releases/latest)
 
@@ -88,7 +88,7 @@ repositories as it is very outdated. Instead, use our custom repo.
   </TabItem>
 </Tabs>
 
-## RPM <Badge text="New" variant="tip" />
+## RPM
 
 [![rpm version from custom repo](https://img.shields.io/github/v/release/kubecolor/kubecolor?label=rpm%20package&color=4cc61f)](https://github.com/kubecolor/kubecolor/releases/latest)
 


### PR DESCRIPTION
# Description

Stuff that was new isn't that new anymore

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## What you changed

Removes the `New` badge from various places


## Why you think we should change it

The RPM, DEB, and MacPorts packages are not that new anymore, and the theme support is also not that new.

## Related issue (if exists)
